### PR TITLE
feat(nix): add rpi-museum home manager target

### DIFF
--- a/hosts.nix
+++ b/hosts.nix
@@ -69,5 +69,10 @@
       system = "aarch64-linux";
       modules = [ ./nixpkgs/home-manager/homepi.nix ];
     };
+    
+    rpi-museum = {
+      system = "aarch64-linux";
+      modules = [ ./nixpkgs/home-manager/rpi-museum.nix ];
+    };
   };
 } 

--- a/nixpkgs/home-manager/rpi-museum.nix
+++ b/nixpkgs/home-manager/rpi-museum.nix
@@ -1,0 +1,15 @@
+{ config, lib, pkgs, ... }:
+
+{
+  imports = [
+    ./modules/linux-common.nix
+  ];
+
+  # Machine-specific packages
+  home.packages = with pkgs; [
+    restic  # for backups
+  ];
+
+  # Disable git signing for rpi-museum (no 1Password setup)
+  programs.git.signing.signByDefault = lib.mkForce false;
+}


### PR DESCRIPTION
## Summary
- Add new `rpi-museum.nix` home manager configuration based on `homepi.nix`
- Register `rpi-museum` target in `hosts.nix` homeManager section
- Uses `aarch64-linux` system architecture with `linux-common` module

## Features
- Includes `restic` package for backups
- Disables git signing (no 1Password setup)
- Follows the same pattern as existing `homepi` configuration

## Usage
```bash
home-manager switch --flake .#rpi-museum
```

🤖 Generated with [Claude Code](https://claude.ai/code)